### PR TITLE
Create SentiVerse Web API skeleton

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+WORKDIR /app
+EXPOSE 80
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+COPY ./src ./src
+RUN dotnet restore src/SentiVerse.Api/SentiVerse.Api.csproj
+RUN dotnet publish src/SentiVerse.Api/SentiVerse.Api.csproj -c Release -o /app/publish
+
+FROM base AS final
+WORKDIR /app
+COPY --from=build /app/publish .
+ENTRYPOINT ["dotnet", "SentiVerse.Api.dll"]

--- a/SentiVerse.sln
+++ b/SentiVerse.sln
@@ -1,0 +1,18 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31912.275
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SentiVerse.Api", "src/SentiVerse.Api/SentiVerse.Api.csproj", "{11111111-1111-1111-1111-111111111111}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SentiVerse.Application", "src/SentiVerse.Application/SentiVerse.Application.csproj", "{22222222-2222-2222-2222-222222222222}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SentiVerse.Domain", "src/SentiVerse.Domain/SentiVerse.Domain.csproj", "{33333333-3333-3333-3333-333333333333}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SentiVerse.Infrastructure", "src/SentiVerse.Infrastructure/SentiVerse.Infrastructure.csproj", "{44444444-4444-4444-4444-444444444444}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SentiVerse.BackgroundTasks", "src/SentiVerse.BackgroundTasks/SentiVerse.BackgroundTasks.csproj", "{55555555-5555-5555-5555-555555555555}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnitTests", "tests/UnitTests/UnitTests.csproj", "{66666666-6666-6666-6666-666666666666}"
+EndProject
+Global
+EndGlobal

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+version: '3.8'
+services:
+  postgres:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: SentiVerse
+    ports:
+      - "5432:5432"
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"
+  hangfire:
+    image: hangfireio/hangfire:1.7.36
+    environment:
+      - Hangfire__Dashboard__Authorization__IsEnabled=true
+    ports:
+      - "8082:80"
+  api:
+    build: .
+    environment:
+      ConnectionStrings__DefaultConnection: Host=postgres;Database=SentiVerse;Username=postgres;Password=postgres
+      Jwt__Key: SuperSecretKey12345
+      EmotionApi__BaseUrl: http://ai-sentiment-api
+    depends_on:
+      - postgres
+      - redis
+    ports:
+      - "8080:80"

--- a/src/SentiVerse.Api/Controllers/AuthController.cs
+++ b/src/SentiVerse.Api/Controllers/AuthController.cs
@@ -1,0 +1,53 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.IdentityModel.Tokens;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using SentiVerse.Application.DTOs.Auth;
+using SentiVerse.Domain.Entities;
+
+namespace SentiVerse.Api.Controllers;
+
+[ApiController]
+[Route("api/auth")]
+public class AuthController : ControllerBase
+{
+    private readonly UserManager<ApplicationUser> _userManager;
+    private readonly IConfiguration _config;
+
+    public AuthController(UserManager<ApplicationUser> userManager, IConfiguration config)
+    {
+        _userManager = userManager;
+        _config = config;
+    }
+
+    [HttpPost("register")]
+    public async Task<IActionResult> Register(RegisterDto dto)
+    {
+        var user = new ApplicationUser { UserName = dto.Username, Email = dto.Email };
+        var result = await _userManager.CreateAsync(user, dto.Password);
+        if (!result.Succeeded)
+            return BadRequest(result.Errors);
+        return Ok();
+    }
+
+    [HttpPost("login")]
+    public async Task<IActionResult> Login(LoginDto dto)
+    {
+        var user = await _userManager.FindByEmailAsync(dto.Email);
+        if (user == null || !await _userManager.CheckPasswordAsync(user, dto.Password))
+            return Unauthorized();
+
+        var tokenHandler = new JwtSecurityTokenHandler();
+        var key = Encoding.UTF8.GetBytes(_config["Jwt:Key"]!);
+        var tokenDescriptor = new SecurityTokenDescriptor
+        {
+            Subject = new ClaimsIdentity(new[] { new Claim(ClaimTypes.NameIdentifier, user.Id.ToString()) }),
+            Expires = DateTime.UtcNow.AddHours(6),
+            SigningCredentials = new SigningCredentials(new SymmetricSecurityKey(key), SecurityAlgorithms.HmacSha256Signature)
+        };
+        var token = tokenHandler.CreateToken(tokenDescriptor);
+        return Ok(new { token = tokenHandler.WriteToken(token) });
+    }
+}

--- a/src/SentiVerse.Api/Controllers/EmotionsController.cs
+++ b/src/SentiVerse.Api/Controllers/EmotionsController.cs
@@ -1,0 +1,33 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using SentiVerse.Application.DTOs.Emotions;
+using Microsoft.AspNetCore.Identity;
+using System.Security.Claims;
+using SentiVerse.Application.Services;
+using SentiVerse.Domain.Entities;
+
+namespace SentiVerse.Api.Controllers;
+
+[ApiController]
+[Route("api/emotions")]
+[Authorize]
+public class EmotionsController : ControllerBase
+{
+    private readonly IEmotionService _emotionService;
+    private readonly UserManager<ApplicationUser> _userManager;
+
+    public EmotionsController(IEmotionService emotionService, UserManager<ApplicationUser> userManager)
+    {
+        _emotionService = emotionService;
+        _userManager = userManager;
+    }
+
+    [HttpPost("capture")]
+    public async Task<IActionResult> Capture(EmotionCaptureDto dto)
+    {
+        var userId = Guid.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
+        var emotion = await _emotionService.AnalyzeEmotionAsync(dto.Text);
+        var group = await _emotionService.SuggestGroupAsync(userId, emotion);
+        return Ok(new { groupId = group.GroupId, emotion });
+    }
+}

--- a/src/SentiVerse.Api/Controllers/GroupsController.cs
+++ b/src/SentiVerse.Api/Controllers/GroupsController.cs
@@ -1,0 +1,51 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+using SentiVerse.Application.DTOs.Groups;
+using SentiVerse.Application.Services;
+using SentiVerse.Infrastructure.Services;
+using SentiVerse.Domain.Entities;
+
+using SentiVerse.Domain.Interfaces;
+namespace SentiVerse.Api.Controllers;
+
+[ApiController]
+[Route("api/groups")]
+[Authorize]
+public class GroupsController : ControllerBase
+{
+    private readonly GroupService _groupService;
+    private readonly RedisMessageCache _cache;
+    private readonly IUnitOfWork _uow;
+
+    public GroupsController(GroupService groupService, RedisMessageCache cache, IUnitOfWork uow)
+    {
+        _groupService = groupService;
+        _cache = cache;
+        _uow = uow;
+    }
+
+    [HttpGet("active")]
+    public async Task<IActionResult> GetActive([FromQuery] string emotionType)
+    {
+        var groups = await _groupService.GetActiveGroupsAsync(emotionType);
+        return Ok(groups);
+    }
+
+    [HttpPost("join")]
+    public async Task<IActionResult> Join(JoinGroupDto dto)
+    {
+        var userId = Guid.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
+        var membership = new GroupMembership { GroupId = dto.GroupId, UserId = userId };
+        await _uow.GroupMemberships.AddAsync(membership);
+        await _uow.SaveChangesAsync();
+        return Ok();
+    }
+
+    [HttpGet("{groupId}/messages")]
+    public async Task<IActionResult> Messages(Guid groupId)
+    {
+        var messages = await _cache.GetMessagesAsync(groupId);
+        return Ok(messages);
+    }
+}

--- a/src/SentiVerse.Api/Hubs/EmotionGroupHub.cs
+++ b/src/SentiVerse.Api/Hubs/EmotionGroupHub.cs
@@ -1,0 +1,33 @@
+using System;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.SignalR;
+using SentiVerse.Domain.Entities;
+using SentiVerse.Infrastructure.Services;
+using System.Security.Claims;
+
+namespace SentiVerse.Api.Hubs;
+
+[Authorize]
+public class EmotionGroupHub : Hub
+{
+    private readonly RedisMessageCache _cache;
+
+    public EmotionGroupHub(RedisMessageCache cache)
+    {
+        _cache = cache;
+    }
+
+    public override async Task OnConnectedAsync()
+    {
+        await base.OnConnectedAsync();
+    }
+
+    public async Task SendMessage(string groupId, string content)
+    {
+        var userId = Guid.Parse(Context.User!.FindFirstValue(ClaimTypes.NameIdentifier)!);
+        await Groups.AddToGroupAsync(Context.ConnectionId, groupId);
+        var message = new Message { MessageId = Guid.NewGuid(), GroupId = Guid.Parse(groupId), UserId = userId, Content = content };
+        await _cache.AddMessageAsync(message);
+        await Clients.Group(groupId).SendAsync("ReceiveMessage", new { message.MessageId, message.UserId, message.Content, message.CreatedAt });
+    }
+}

--- a/src/SentiVerse.Api/Program.cs
+++ b/src/SentiVerse.Api/Program.cs
@@ -1,0 +1,85 @@
+using Hangfire;
+using Hangfire.MemoryStorage;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.IdentityModel.Tokens;
+using Serilog;
+using SentiVerse.Application.Services;
+using SentiVerse.BackgroundTasks.Jobs;
+using SentiVerse.Domain.Entities;
+using SentiVerse.Domain.Interfaces;
+using SentiVerse.Infrastructure.Persistence;
+using SentiVerse.Infrastructure.Repositories;
+using SentiVerse.Infrastructure.Services;
+using System.Text;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Host.UseSerilog((ctx, lc) => lc
+    .WriteTo.Console()
+    .WriteTo.File("logs/log.txt", rollingInterval: RollingInterval.Day));
+
+var connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
+builder.Services.AddDbContext<ApplicationDbContext>(options =>
+    options.UseNpgsql(connectionString));
+
+builder.Services.AddIdentity<ApplicationUser, IdentityRole<Guid>>()
+    .AddEntityFrameworkStores<ApplicationDbContext>()
+    .AddDefaultTokenProviders();
+
+builder.Services.AddAuthentication(options =>
+{
+    options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+    options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+}).AddJwtBearer(options =>
+{
+    options.TokenValidationParameters = new TokenValidationParameters
+    {
+        ValidateIssuer = false,
+        ValidateAudience = false,
+        ValidateLifetime = true,
+        ValidateIssuerSigningKey = true,
+        IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(builder.Configuration["Jwt:Key"]!))
+    };
+});
+
+builder.Services.AddHttpClient<IEmotionService, EmotionService>(client =>
+{
+    client.BaseAddress = new Uri(builder.Configuration["EmotionApi:BaseUrl"]!);
+});
+
+builder.Services.AddScoped<IUnitOfWork, UnitOfWork>();
+builder.Services.AddScoped<RedisMessageCache>();
+builder.Services.AddScoped<GroupService>();
+builder.Services.AddHangfire(x => x.UseMemoryStorage());
+builder.Services.AddHangfireServer();
+
+builder.Services.AddSignalR();
+
+builder.Services.AddControllers();
+
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseSerilogRequestLogging();
+
+app.UseRouting();
+app.UseAuthentication();
+app.UseAuthorization();
+
+app.UseHangfireDashboard();
+RecurringJob.AddOrUpdate<GroupArchiveJob>("archive-groups", job => job.ArchiveExpiredGroupsAsync(), Cron.MinuteInterval(30));
+
+app.MapControllers();
+app.MapHub<SentiVerse.Api.Hubs.EmotionGroupHub>("/hubs/emotion");
+
+app.Run();

--- a/src/SentiVerse.Api/SentiVerse.Api.csproj
+++ b/src/SentiVerse.Api/SentiVerse.Api.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
+    <PackageReference Include="Hangfire.AspNetCore" Version="1.7.36" />
+    <PackageReference Include="StackExchange.Redis" Version="2.6.66" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../SentiVerse.Application/SentiVerse.Application.csproj" />
+    <ProjectReference Include="../SentiVerse.Infrastructure/SentiVerse.Infrastructure.csproj" />
+    <ProjectReference Include="../SentiVerse.Domain/SentiVerse.Domain.csproj" />
+    <ProjectReference Include="../SentiVerse.BackgroundTasks/SentiVerse.BackgroundTasks.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/SentiVerse.Api/appsettings.json
+++ b/src/SentiVerse.Api/appsettings.json
@@ -1,0 +1,17 @@
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Host=postgres;Database=SentiVerse;Username=postgres;Password=postgres"
+  },
+  "Jwt": {
+    "Key": "SuperSecretKey12345"
+  },
+  "EmotionApi": {
+    "BaseUrl": "http://ai-sentiment-api"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/SentiVerse.Application/DTOs/Auth/LoginDto.cs
+++ b/src/SentiVerse.Application/DTOs/Auth/LoginDto.cs
@@ -1,0 +1,3 @@
+namespace SentiVerse.Application.DTOs.Auth;
+
+public record LoginDto(string Email, string Password);

--- a/src/SentiVerse.Application/DTOs/Auth/RegisterDto.cs
+++ b/src/SentiVerse.Application/DTOs/Auth/RegisterDto.cs
@@ -1,0 +1,3 @@
+namespace SentiVerse.Application.DTOs.Auth;
+
+public record RegisterDto(string Username, string Email, string Password);

--- a/src/SentiVerse.Application/DTOs/Emotions/EmotionCaptureDto.cs
+++ b/src/SentiVerse.Application/DTOs/Emotions/EmotionCaptureDto.cs
@@ -1,0 +1,3 @@
+namespace SentiVerse.Application.DTOs.Emotions;
+
+public record EmotionCaptureDto(string Text);

--- a/src/SentiVerse.Application/DTOs/Groups/JoinGroupDto.cs
+++ b/src/SentiVerse.Application/DTOs/Groups/JoinGroupDto.cs
@@ -1,0 +1,5 @@
+using System;
+
+namespace SentiVerse.Application.DTOs.Groups;
+
+public record JoinGroupDto(Guid GroupId);

--- a/src/SentiVerse.Application/DTOs/Groups/MessageDto.cs
+++ b/src/SentiVerse.Application/DTOs/Groups/MessageDto.cs
@@ -1,0 +1,5 @@
+using System;
+
+namespace SentiVerse.Application.DTOs.Groups;
+
+public record MessageDto(Guid GroupId, string Content);

--- a/src/SentiVerse.Application/SentiVerse.Application.csproj
+++ b/src/SentiVerse.Application/SentiVerse.Application.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../SentiVerse.Domain/SentiVerse.Domain.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/SentiVerse.Application/Services/EmotionService.cs
+++ b/src/SentiVerse.Application/Services/EmotionService.cs
@@ -1,0 +1,39 @@
+using System.Net.Http.Json;
+using SentiVerse.Domain.Entities;
+using SentiVerse.Domain.Interfaces;
+
+namespace SentiVerse.Application.Services;
+
+public class EmotionService : IEmotionService
+{
+    private readonly HttpClient _httpClient;
+    private readonly IUnitOfWork _uow;
+
+    public EmotionService(HttpClient httpClient, IUnitOfWork uow)
+    {
+        _httpClient = httpClient;
+        _uow = uow;
+    }
+
+    public async Task<string> AnalyzeEmotionAsync(string text)
+    {
+        var response = await _httpClient.PostAsJsonAsync("/analyze-sentiment", new { text });
+        var result = await response.Content.ReadFromJsonAsync<SentimentResponse>() ?? new SentimentResponse();
+        return result.label ?? "";
+    }
+
+    public async Task<EmotionGroup> SuggestGroupAsync(Guid userId, string emotionType)
+    {
+        var groups = await _uow.EmotionGroups.GetAllAsync();
+        var group = groups.FirstOrDefault(g => g.EmotionType == emotionType && g.IsActive);
+        if (group == null)
+        {
+            group = new EmotionGroup { GroupId = Guid.NewGuid(), EmotionType = emotionType };
+            await _uow.EmotionGroups.AddAsync(group);
+            await _uow.SaveChangesAsync();
+        }
+        return group;
+    }
+
+    private record SentimentResponse(string? label = null, double score = 0);
+}

--- a/src/SentiVerse.Application/Services/GroupService.cs
+++ b/src/SentiVerse.Application/Services/GroupService.cs
@@ -1,0 +1,20 @@
+using SentiVerse.Domain.Entities;
+using SentiVerse.Domain.Interfaces;
+
+namespace SentiVerse.Application.Services;
+
+public class GroupService
+{
+    private readonly IUnitOfWork _uow;
+
+    public GroupService(IUnitOfWork uow)
+    {
+        _uow = uow;
+    }
+
+    public async Task<IEnumerable<EmotionGroup>> GetActiveGroupsAsync(string emotionType)
+    {
+        var groups = await _uow.EmotionGroups.GetAllAsync();
+        return groups.Where(g => g.EmotionType == emotionType && g.IsActive);
+    }
+}

--- a/src/SentiVerse.BackgroundTasks/Jobs/GroupArchiveJob.cs
+++ b/src/SentiVerse.BackgroundTasks/Jobs/GroupArchiveJob.cs
@@ -1,0 +1,28 @@
+using Microsoft.Extensions.Logging;
+using SentiVerse.Domain.Interfaces;
+
+namespace SentiVerse.BackgroundTasks.Jobs;
+
+public class GroupArchiveJob
+{
+    private readonly IUnitOfWork _uow;
+    private readonly ILogger<GroupArchiveJob> _logger;
+
+    public GroupArchiveJob(IUnitOfWork uow, ILogger<GroupArchiveJob> logger)
+    {
+        _uow = uow;
+        _logger = logger;
+    }
+
+    public async Task ArchiveExpiredGroupsAsync()
+    {
+        var groups = await _uow.EmotionGroups.GetAllAsync();
+        var expired = groups.Where(g => g.CreatedAt <= DateTime.UtcNow.AddHours(-6) && g.IsActive).ToList();
+        foreach (var group in expired)
+        {
+            group.IsActive = false;
+        }
+        await _uow.SaveChangesAsync();
+        _logger.LogInformation("Archived {Count} groups", expired.Count);
+    }
+}

--- a/src/SentiVerse.BackgroundTasks/SentiVerse.BackgroundTasks.csproj
+++ b/src/SentiVerse.BackgroundTasks/SentiVerse.BackgroundTasks.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Hangfire.AspNetCore" Version="1.7.36" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../SentiVerse.Infrastructure/SentiVerse.Infrastructure.csproj" />
+    <ProjectReference Include="../SentiVerse.Domain/SentiVerse.Domain.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/SentiVerse.Domain/Entities/EmotionCapture.cs
+++ b/src/SentiVerse.Domain/Entities/EmotionCapture.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace SentiVerse.Domain.Entities;
+
+public class EmotionCapture
+{
+    public Guid CaptureId { get; set; }
+    public Guid UserId { get; set; }
+    public string EmotionType { get; set; } = string.Empty;
+    public string CaptureContent { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/src/SentiVerse.Domain/Entities/EmotionGroup.cs
+++ b/src/SentiVerse.Domain/Entities/EmotionGroup.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+
+namespace SentiVerse.Domain.Entities;
+
+public class EmotionGroup
+{
+    public Guid GroupId { get; set; }
+    public string EmotionType { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public bool IsActive { get; set; } = true;
+    public ICollection<GroupMembership> Members { get; set; } = new List<GroupMembership>();
+}

--- a/src/SentiVerse.Domain/Entities/GroupMembership.cs
+++ b/src/SentiVerse.Domain/Entities/GroupMembership.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace SentiVerse.Domain.Entities;
+
+public class GroupMembership
+{
+    public Guid GroupId { get; set; }
+    public Guid UserId { get; set; }
+    public DateTime JoinedAt { get; set; } = DateTime.UtcNow;
+}

--- a/src/SentiVerse.Domain/Entities/Message.cs
+++ b/src/SentiVerse.Domain/Entities/Message.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace SentiVerse.Domain.Entities;
+
+public class Message
+{
+    public Guid MessageId { get; set; }
+    public Guid GroupId { get; set; }
+    public Guid UserId { get; set; }
+    public string Content { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/src/SentiVerse.Domain/Entities/User.cs
+++ b/src/SentiVerse.Domain/Entities/User.cs
@@ -1,0 +1,9 @@
+using System;
+using Microsoft.AspNetCore.Identity;
+
+namespace SentiVerse.Domain.Entities;
+
+public class ApplicationUser : IdentityUser<Guid>
+{
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/src/SentiVerse.Domain/Interfaces/IEmotionService.cs
+++ b/src/SentiVerse.Domain/Interfaces/IEmotionService.cs
@@ -1,0 +1,9 @@
+using SentiVerse.Domain.Entities;
+
+namespace SentiVerse.Domain.Interfaces;
+
+public interface IEmotionService
+{
+    Task<string> AnalyzeEmotionAsync(string text);
+    Task<EmotionGroup> SuggestGroupAsync(Guid userId, string emotionType);
+}

--- a/src/SentiVerse.Domain/Interfaces/IUnitOfWork.cs
+++ b/src/SentiVerse.Domain/Interfaces/IUnitOfWork.cs
@@ -1,0 +1,18 @@
+using SentiVerse.Domain.Entities;
+
+namespace SentiVerse.Domain.Interfaces;
+
+public interface IUnitOfWork
+{
+    IRepository<EmotionGroup> EmotionGroups { get; }
+    IRepository<GroupMembership> GroupMemberships { get; }
+    IRepository<Message> Messages { get; }
+    Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
+}
+
+public interface IRepository<T> where T : class
+{
+    Task<T?> GetByIdAsync(Guid id);
+    Task AddAsync(T entity);
+    Task<IEnumerable<T>> GetAllAsync();
+}

--- a/src/SentiVerse.Domain/SentiVerse.Domain.csproj
+++ b/src/SentiVerse.Domain/SentiVerse.Domain.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/src/SentiVerse.Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/src/SentiVerse.Infrastructure/Persistence/ApplicationDbContext.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using SentiVerse.Domain.Entities;
+
+namespace SentiVerse.Infrastructure.Persistence;
+
+public class ApplicationDbContext : IdentityDbContext<ApplicationUser, IdentityRole<Guid>, Guid>
+{
+    public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
+        : base(options)
+    {
+    }
+
+    public DbSet<EmotionCapture> EmotionCaptures => Set<EmotionCapture>();
+    public DbSet<EmotionGroup> EmotionGroups => Set<EmotionGroup>();
+    public DbSet<GroupMembership> GroupMemberships => Set<GroupMembership>();
+    public DbSet<Message> Messages => Set<Message>();
+
+    protected override void OnModelCreating(ModelBuilder builder)
+    {
+        base.OnModelCreating(builder);
+    }
+}

--- a/src/SentiVerse.Infrastructure/Repositories/Repository.cs
+++ b/src/SentiVerse.Infrastructure/Repositories/Repository.cs
@@ -1,0 +1,32 @@
+using Microsoft.EntityFrameworkCore;
+using SentiVerse.Infrastructure.Persistence;
+using SentiVerse.Domain.Interfaces;
+
+namespace SentiVerse.Infrastructure.Repositories;
+
+public class Repository<T> : IRepository<T> where T : class
+{
+    private readonly ApplicationDbContext _context;
+    private readonly DbSet<T> _dbSet;
+
+    public Repository(ApplicationDbContext context)
+    {
+        _context = context;
+        _dbSet = context.Set<T>();
+    }
+
+    public async Task AddAsync(T entity)
+    {
+        await _dbSet.AddAsync(entity);
+    }
+
+    public async Task<IEnumerable<T>> GetAllAsync()
+    {
+        return await _dbSet.ToListAsync();
+    }
+
+    public async Task<T?> GetByIdAsync(Guid id)
+    {
+        return await _dbSet.FindAsync(id);
+    }
+}

--- a/src/SentiVerse.Infrastructure/Repositories/UnitOfWork.cs
+++ b/src/SentiVerse.Infrastructure/Repositories/UnitOfWork.cs
@@ -1,0 +1,27 @@
+using SentiVerse.Domain.Entities;
+using SentiVerse.Domain.Interfaces;
+using SentiVerse.Infrastructure.Persistence;
+
+namespace SentiVerse.Infrastructure.Repositories;
+
+public class UnitOfWork : IUnitOfWork
+{
+    private readonly ApplicationDbContext _context;
+
+    public IRepository<EmotionGroup> EmotionGroups { get; }
+    public IRepository<GroupMembership> GroupMemberships { get; }
+    public IRepository<Message> Messages { get; }
+
+    public UnitOfWork(ApplicationDbContext context)
+    {
+        _context = context;
+        EmotionGroups = new Repository<EmotionGroup>(context);
+        GroupMemberships = new Repository<GroupMembership>(context);
+        Messages = new Repository<Message>(context);
+    }
+
+    public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+    {
+        return _context.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/SentiVerse.Infrastructure/SentiVerse.Infrastructure.csproj
+++ b/src/SentiVerse.Infrastructure/SentiVerse.Infrastructure.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="StackExchange.Redis" Version="2.6.66" />
+    <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../SentiVerse.Domain/SentiVerse.Domain.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/SentiVerse.Infrastructure/Services/RedisMessageCache.cs
+++ b/src/SentiVerse.Infrastructure/Services/RedisMessageCache.cs
@@ -1,0 +1,29 @@
+using StackExchange.Redis;
+using SentiVerse.Domain.Entities;
+
+namespace SentiVerse.Infrastructure.Services;
+
+public class RedisMessageCache
+{
+    private readonly IDatabase _db;
+    private const string Prefix = "group_messages:";
+
+    public RedisMessageCache(IConnectionMultiplexer connection)
+    {
+        _db = connection.GetDatabase();
+    }
+
+    public async Task AddMessageAsync(Message message)
+    {
+        var key = Prefix + message.GroupId;
+        var serialized = System.Text.Json.JsonSerializer.Serialize(message);
+        await _db.ListRightPushAsync(key, serialized);
+    }
+
+    public async Task<IEnumerable<Message>> GetMessagesAsync(Guid groupId, int count = 50)
+    {
+        var key = Prefix + groupId;
+        var entries = await _db.ListRangeAsync(key, -count, -1);
+        return entries.Select(e => System.Text.Json.JsonSerializer.Deserialize<Message>(e!)).Where(m => m != null)!;
+    }
+}

--- a/tests/UnitTests/SampleTests.cs
+++ b/tests/UnitTests/SampleTests.cs
@@ -1,0 +1,12 @@
+using Xunit;
+
+namespace UnitTests;
+
+public class SampleTests
+{
+    [Fact]
+    public void BasicTest()
+    {
+        Assert.True(1 == 1);
+    }
+}

--- a/tests/UnitTests/UnitTests.csproj
+++ b/tests/UnitTests/UnitTests.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/SentiVerse.Api/SentiVerse.Api.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- implement Clean Architecture style project for .NET 8
- add API controllers for auth, emotions and groups
- add SignalR hub and Hangfire job
- configure EF Core, Identity, Redis, Serilog and JWT
- provide Dockerfile and docker-compose setup
- add minimal xUnit test project

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6855c5396dec83228fbef9c4b358b4b5